### PR TITLE
送信完了後にtmpStrokeをnullにしてしまうと、送信中に次のストロークを書き始めたときにtmpStrokeが消えてエラーになってしまう

### DIFF
--- a/webapp/react/components/Room.jsx
+++ b/webapp/react/components/Room.jsx
@@ -118,7 +118,6 @@ class Room extends React.Component {
         const stroke = res.stroke;
         this.setState({
           strokes: this.state.strokes.concat([stroke]),
-          tmpStroke: null,
         });
       })
       .catch((err) => {


### PR DESCRIPTION
fix #44 
