### PR TITLE
CSRFトークンのチェックシナリオ修正

### DIFF
--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -140,7 +140,7 @@ func CheckCSRFTokenRefreshed(origins []string) {
 		return
 	}
 
-	if token1 != token2 {
+	if token1 == token2 {
 		fails.Critical("csrf_tokenが使いまわされています", nil)
 	}
 }


### PR DESCRIPTION
python実装でlocal-benchを回してみたらエラーになったのですが、おそらく逆ではないかと。
