### PR TITLE
Dockerfile for local-bench

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,6 +1,5 @@
 /isucon6f
 /vendor
-/glide.lock
 /local-bench
 /local-audience
 /local-worker

--- a/bench/Dockerfile
+++ b/bench/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${GOPATH}/src/github.com/catatsuy/isucon6-final/bench
 COPY . ${GOPATH}/src/github.com/catatsuy/isucon6-final/bench
 
 RUN \
-  glide update && \
+  glide install && \
   make
 
 #CMD ["./local-bench", "-urls", "https://react", "-timeout", "30"]

--- a/bench/glide.lock
+++ b/bench/glide.lock
@@ -1,0 +1,20 @@
+hash: 262dc7f8271b3fc89972aee1c9c508b004d933ed2839de77634e75f4fb1db918
+updated: 2016-10-09T02:30:00.135165487Z
+imports:
+- name: github.com/andybalholm/cascadia
+  version: 1c31af6f6c1a7b101ed05aacc7d8a738b43ae86e
+- name: github.com/mitchellh/go-homedir
+  version: 756f7b183b7ab78acdbbee5c7f392838ed459dda
+- name: github.com/PuerkitoBio/goquery
+  version: 56a198aba89cdf7a612e6c762eff9d788b9f2dae
+- name: github.com/Songmu/timeout
+  version: 84831c43cf48f6b1d52c64ed499d714ffd62eca1
+- name: golang.org/x/net
+  version: f4b625ec9b21d620bb5ce57f2dfc3e08ca97fce6
+  subpackages:
+  - html
+  - html/atom
+  - http2/hpack
+  - idna
+  - lex/httplex
+testImports: []


### PR DESCRIPTION
手元でテストするのにDockerfileがあると便利なので。
- glideとgo-bindataの用意の仕方がこれでいいのかわからない
- local-workerの使い方がよくわかってない
- Docker for Mac環境でurlsにホスト名で指定する場合、/etc/resolv.confのsearch localの行を削除しないとベンチマークが走らない(Docker for Macとgolangの相性問題？)
