### PR TITLE
Go実装のwatcherCountを代入してからprintする

### DIFF
--- a/webapp/go/app.go
+++ b/webapp/go/app.go
@@ -459,8 +459,8 @@ func getAPIStreamRoomsID(ctx context.Context, w http.ResponseWriter, r *http.Req
 			return
 		}
 		if newWatcherCount != watcherCount {
-			printAndFlush(w, "event:watcher_count\n"+"data:"+strconv.Itoa(watcherCount)+"\n\n")
 			watcherCount = newWatcherCount
+			printAndFlush(w, "event:watcher_count\n"+"data:"+strconv.Itoa(watcherCount)+"\n\n")
 		}
 	}
 }


### PR DESCRIPTION
`new_watcher_count`を返すよりも、watcher_countに先に代入する方が良い？
#118
