### PR TITLE
Python: python2に差し替え

### DIFF
--- a/webapp/python/Dockerfile
+++ b/webapp/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:2-alpine
 
 WORKDIR /var/www
 

--- a/webapp/python/Dockerfile-dev
+++ b/webapp/python/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:2-alpine
 
 WORKDIR /var/www
 

--- a/webapp/python/app.py
+++ b/webapp/python/app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import os
-from datetime import timezone
+from datetime import timedelta, tzinfo
 import time
 
 import MySQLdb.cursors
@@ -52,9 +52,20 @@ def type_cast_point_data(data):
     }
 
 
+class UTC(tzinfo):
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
+
 def to_RFC3339_micro(date):
     # RFC3339では+00:00のときはZにするという仕様だが、pythonは準拠していないため
-    return date.replace(tzinfo=timezone.utc).isoformat().replace('+00:00', 'Z')
+    return date.replace(tzinfo=UTC()).isoformat().replace('+00:00', 'Z')
 
 
 def type_cast_stroke_data(data):


### PR DESCRIPTION
- #171 の調査中、python3+gunicorn構成だとSSEが正しく動作しないことが判明
  - yield実行後の処理が呼ばれていない模様
  - 理由はよくわかってない
  - python3+gunicornは安定していない？
- python2であればgunicornであっても動作に問題がないことを確認したため差し替え
  - datetime.timezoneはpython3からの実装のためpython2用に差し替え
