### PR TITLE
Fix seed/bindata.go makefile issue

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -13,4 +13,4 @@ isucon6f: isucon6f/bench isucon6f/worker
 seed/bindata.go:
 	$(MAKE) -C seed
 
-.PHONY: local
+.PHONY: local seed/bindata.go

--- a/bench/seed/Makefile
+++ b/bench/seed/Makefile
@@ -3,5 +3,3 @@ bindata.go: data/*.json
 
 test: bindata.go
 	go test
-
-.PHONY: bindata.go


### PR DESCRIPTION
- benchディレクトリでmakeを叩いてもseed/bindata.goが更新されない問題を修正
  - bench/Makefileのseed/bindata.goに依存関係の記述がないため更新されない
