### PR TITLE
Remove docker-compose-all*.yml from provisioning tarball, #166

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -12,7 +12,7 @@ build:
     - script:
         name: parepare webapp 
         code: |
-          tar zcf output/webapp.tar.gz --exclude=.gitignore webapp
+          tar zcf output/webapp.tar.gz --exclude=.gitignore --exclude=docker-compose-all*.yml webapp
     - script:
         name: parepare ansible 
         code: |


### PR DESCRIPTION
プロビジョニング用tarballにdocker-compose-all*.ymlを含まないよう明示的にexclude指定
