### PR TITLE
[WIP] Fix executed ResultSet is not closed; cause Mysql2::Error

### DIFF
--- a/webapp/ruby/lib/isuketch/web.rb
+++ b/webapp/ruby/lib/isuketch/web.rb
@@ -101,9 +101,9 @@ module Isuketch
 
       def select_one(sql, *params)
         rs = db.prepare(sql).execute(*params)
-        row = rs.first
+        rs.first
+      ensure
         rs.free
-        row
       end
 
       def check_token(csrf_token)


### PR DESCRIPTION
ResultSetを閉じていないと以下のエラーが発生するので、 `#to_a` して一度すべての `ResultSet` を取得した上で `#first` するようにコードを変更します。

Fixed:

```
Mysql2::Error - Commands out of sync; you can't run this command now:
```

以下のissueで報告のあった問題の修正です。
Ruby: -initialcheck でMySQLのエラー #206
