### PR TITLE
初回起動時にreload systemctlがまとめられてしまうのでnginxが起動しない

### DIFF
--- a/provisioning/proxy/ansible/01_settings.yml
+++ b/provisioning/proxy/ansible/01_settings.yml
@@ -56,7 +56,8 @@
         dest=/etc/systemd/system/nginx.service
         owner=root
         mode=644
-      notify: reload systemctl
+    - name: daemon-reload systemctl
+      command: systemctl daemon-reload
     - name: nginx service enabled
       service: name=nginx state=started enabled=yes
     - name: place reload script


### PR DESCRIPTION
notifyが1つにまとめられてしまうのでsystemctlの設定更新が最後になってしまう。これだとnginxが起動できないので無理矢理やる
