### PR TITLE
out of range防止

### DIFF
--- a/bench/svg/parse.go
+++ b/bench/svg/parse.go
@@ -43,7 +43,7 @@ func Parse(data []byte) (*SVG, error) {
 		for _, s := range strings.Split(polyLine.PointsRaw, " ") {
 			ps := strings.Split(s, ",")
 			if len(ps) < 2 {
-				return nil, errors.New("polylineの形式が不正です")
+				return nil, errors.New("svgの形式が不正です")
 			}
 
 			x, err := strconv.ParseFloat(ps[0], 32)


### PR DESCRIPTION
```
panic: runtime error: index out of range

goroutine 5 [running]:
panic(0x6d3b80, 0xc42000e080)
    /usr/local/opt/go/libexec/src/runtime/panic.go:500 +0x1a1
github.com/catatsuy/isucon6-final/bench/svg.Parse(0xc4201ca000, 0x1243, 0x1e00, 0x1243, 0x1e00, 0x0)
    /Users/cyrill/workspace/go/src/github.com/catatsuy/isucon6-final/bench/svg/parse.go:48 +0x3e7
github.com/catatsuy/isucon6-final/bench/scenario.checkStrokeReflectedToSVG.func1(0x7f32395d0200, 0xc420269280, 0xc42029c620, 0x4e4075)
    /Users/cyrill/workspace/go/src/github.com/catatsuy/isucon6-final/bench/scenario/misc.go:106 +0x96
github.com/catatsuy/isucon6-final/bench/action.StatusChecker.Check(0xc8, 0xc4201663c0, 0x7f32395d0200, 0xc420269280, 0xc42029c620, 0x7f32395d0200)
    /Users/cyrill/workspace/go/src/github.com/catatsuy/isucon6-final/bench/action/action.go:38 +0x44
github.com/catatsuy/isucon6-final/bench/action.(*StatusChecker).Check(0xc42029c610, 0x7f32395d0200, 0xc420269280, 0xc42029c620, 0xc420269280)
    <autogenerated>:1 +0x79
github.com/catatsuy/isucon6-final/bench/action.request(0xc42031e680, 0x72be9f, 0x3, 0xc42029c600, 0x9, 0x0, 0x0, 0x0, 0x88b6e0, 0xc42029c610, ...)
    /Users/cyrill/workspace/go/src/github.com/catatsuy/isucon6-final/bench/action/action.go:105 +0x421
github.com/catatsuy/isucon6-final/bench/action.Get(0xc42031e680, 0xc42029c600, 0x9, 0x88b6e0, 0xc42029c610, 0xc42029c600)
    /Users/cyrill/workspace/go/src/github.com/catatsuy/isucon6-final/bench/action/action.go:109 +0x90
github.com/catatsuy/isucon6-final/bench/scenario.checkStrokeReflectedToSVG(0xc42031e680, 0x42f, 0xa202, 0x14, 0xa9, 0x69, 0x77, 0x3f333333, 0xc4200af400, 0x1c, ...)
    /Users/cyrill/workspace/go/src/github.com/catatsuy/isucon6-final/bench/scenario/misc.go:130 +0x177
github.com/catatsuy/isucon6-final/bench/scenario.StrokeReflectedToTop(0xc4200739a0, 0xa, 0xa)
    /Users/cyrill/workspace/go/src/github.com/catatsuy/isucon6-final/bench/scenario/initial_check.go:122 +0xc7a
main.initialCheck.func1(0xc42000f920, 0xc4200739a0, 0xa, 0xa)
    /Users/cyrill/repos/github.com/others/isucon6-final/bench/cmd/bench/main.go:81 +0x91
created by main.initialCheck
    /Users/cyrill/repos/github.com/others/isucon6-final/bench/cmd/bench/main.go:87 +0x9c
```
