### PR TITLE
benchのインスタンスサイズをStandard_DS3_v2に

### DIFF
--- a/provisioning/bench/deploy.json
+++ b/provisioning/bench/deploy.json
@@ -44,7 +44,7 @@
       "tags": {},
       "properties": {
         "hardwareProfile": {
-          "vmSize": "Standard_F2"
+          "vmSize": "Standard_DS3_v2"
         },
         "storageProfile": {
           "imageReference": {

--- a/provisioning/bench/deploy.json.template
+++ b/provisioning/bench/deploy.json.template
@@ -44,7 +44,7 @@
       "tags": {},
       "properties": {
         "hardwareProfile": {
-          "vmSize": "Standard_F2"
+          "vmSize": "Standard_DS3_v2"
         },
         "storageProfile": {
           "imageReference": {

--- a/provisioning/deploy.json
+++ b/provisioning/deploy.json
@@ -136,7 +136,7 @@
       "tags": {},
       "properties": {
         "hardwareProfile": {
-          "vmSize": "Standard_F2"
+          "vmSize": "Standard_DS3_v2"
         },
         "storageProfile": {
           "imageReference": {


### PR DESCRIPTION
benchはCPUを多く使うため4コアであるStandard_DS3_v2にする予定だった。しかしISUCON本選当日までに変更することを忘れていた。

本選当日はCPUの限界に到達したチームは優勝チームのみだったため、ISUCON本選の結果自体には影響を与えていない。しかし、4コアなければCPUの限界に到達してしまうため、途中から正しいベンチ結果を計測できない。

そこでISUCON当日とは異なるが、本来使う予定であったインスタンスサイズに変更する。

refs #201 