### PR TITLE
パッチを当てずに証明書を無視するクライアントでHTTP2を使えるようにする

### DIFF
--- a/bench/action/action.go
+++ b/bench/action/action.go
@@ -2,16 +2,14 @@ package action
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 
-	"fmt"
-
-	"errors"
-
 	"github.com/isucon/isucon6-final/bench/fails"
-	"github.com/isucon/isucon6-final/bench/http"
 	"github.com/isucon/isucon6-final/bench/score"
 	"github.com/isucon/isucon6-final/bench/session"
 	"github.com/isucon/isucon6-final/bench/sse"

--- a/bench/session/session.go
+++ b/bench/session/session.go
@@ -3,11 +3,12 @@ package session
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"time"
 
-	"github.com/isucon/isucon6-final/bench/http"
-	"github.com/isucon/isucon6-final/bench/http/cookiejar"
+	"golang.org/x/net/http2"
 )
 
 const (
@@ -31,6 +32,12 @@ func New(baseURL string) *Session {
 			InsecureSkipVerify: true,
 		},
 		MaxIdleConnsPerHost: MaxIdleConnsPerHost,
+	}
+
+	// TLSClientConfigを渡すとhttp2が使えないので、強制的にhttp2も使えるようにする
+	// Transportを外から渡すことでコネクションを共有させない
+	if err := http2.ConfigureTransport(s.Transport); err != nil {
+		panic(fmt.Errorf("Failed to configure h2 transport: %s", err))
 	}
 
 	jar, _ := cookiejar.New(nil)

--- a/bench/sse/eventsource.go
+++ b/bench/sse/eventsource.go
@@ -4,12 +4,11 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/isucon/isucon6-final/bench/http"
 )
 
 type Listener func(data string)


### PR DESCRIPTION
http2.ConfigureTransportを呼び出すことでパッチを当てなくても

  * HTTP2を使える
  * コネクションを都度生成する

という挙動を実現できた。
`github.com/isucon/isucon6-final/bench/http` を削除しても動くようになっている。
cf: http://qiita.com/catatsuy/items/ee4fc094c6b9c39ee08f